### PR TITLE
Hot reload fix for development environments

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,18 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
-export default prisma;
+let prisma
+
+if ( process.env.NODE_ENV === "production" ) {
+  // spin-up a Prisma client always on the production copy.
+  prisma = new PrismaClient()
+  
+} else {
+   // to prevent Prisma spinning-up too many clients in a development environment, check to see if one is already running
+  if (!global.prisma) {
+    global.prisma = new PrismaClient()
+  }
+  
+  prisma = global.prisma
+}
+
+export default prisma


### PR DESCRIPTION
Next.js hot reloading on a development environment creates a new instance of Prisma (and any other database client). See https://github.com/vercel/next.js/issues/7811. This checks the environment of the Next.js app, and spins-up a Prisma instance accordingly.